### PR TITLE
Reworks system and devices

### DIFF
--- a/emulator/core/src/devices.rs
+++ b/emulator/core/src/devices.rs
@@ -179,6 +179,10 @@ pub trait DynDevice: Any + 'static + Transmutable {}
 
 pub type Device = Rc<RefCell<dyn DynDevice>>;
 
+pub fn wrap_device<T: DynDevice>(value: T) -> Device {
+    Rc::new(RefCell::new(value))
+}
+
 impl<T> DynDevice for T where T: Transmutable + 'static {}
 
 pub trait Transmutable {

--- a/emulator/core/src/devices.rs
+++ b/emulator/core/src/devices.rs
@@ -1,6 +1,8 @@
+use std::any::{Any, TypeId};
+use std::ops::Deref;
 use std::rc::Rc;
-use std::cell::{RefCell, RefMut, BorrowMutError};
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::cell::RefCell;
+use std::sync::atomic::{AtomicU32, Ordering};
 use femtos::{Duration, Instant};
 
 use crate::{Error, System};
@@ -172,6 +174,13 @@ pub trait Inspectable {
 }
 
 
+pub type DeviceId = u32;
+pub trait Resource: Any + 'static + Transmutable {}
+
+pub type Device = Rc<RefCell<dyn Resource>>;
+
+impl<T> Resource for T where T: Transmutable + 'static {}
+
 pub trait Transmutable {
     #[inline]
     fn as_steppable(&mut self) -> Option<&mut dyn Steppable> {
@@ -199,54 +208,76 @@ pub trait Transmutable {
     }
 }
 
+// Taken from deno_core
+fn is<T: Resource>(field: &dyn Resource) -> bool {
+    field.type_id() == TypeId::of::<T>()
+}
+
+// Taken from deno_core
+pub fn downcast_rc_refc<'a, T: Resource>(field: &'a Device) -> Option<&'a Rc<RefCell<T>>> {
+    if is::<T>(field.borrow().deref()) {
+        let ptr = field as *const Rc<RefCell<_>> as *const Rc<RefCell<T>>;
+        #[allow(clippy::undocumented_unsafe_blocks)]
+        Some(unsafe { &*ptr })
+    } else {
+        None
+    }
+}
+
 pub type TransmutableBox = Rc<RefCell<Box<dyn Transmutable>>>;
 
 pub fn wrap_transmutable<T: Transmutable + 'static>(value: T) -> TransmutableBox {
     Rc::new(RefCell::new(Box::new(value)))
 }
 
-static NEXT_ID: AtomicUsize = AtomicUsize::new(1);
+static NEXT_ID: AtomicU32 = AtomicU32::new(1);
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub struct DeviceId(usize);
-
-impl DeviceId {
-    pub fn new() -> Self {
-        let next = NEXT_ID.load(Ordering::Acquire);
-        NEXT_ID.store(next + 1, Ordering::Release);
-        Self(next)
-    }
+pub fn get_next_id() -> u32 {
+    let next = NEXT_ID.load(Ordering::Acquire);
+    NEXT_ID.store(next + 1, Ordering::Release);
+    next
 }
 
-impl Default for DeviceId {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+// #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+// pub struct DeviceId(usize);
 
-#[derive(Clone)]
-pub struct Device(DeviceId, TransmutableBox);
+// impl DeviceId {
+//     pub fn new() -> Self {
+//         let next = NEXT_ID.load(Ordering::Acquire);
+//         NEXT_ID.store(next + 1, Ordering::Release);
+//         Self(next)
+//     }
+// }
 
-impl Device {
-    pub fn new<T>(value: T) -> Self
-    where
-        T: Transmutable + 'static,
-    {
-        Self(DeviceId::new(), wrap_transmutable(value))
-    }
+// impl Default for DeviceId {
+//     fn default() -> Self {
+//         Self::new()
+//     }
+// }
 
-    pub fn id(&self) -> DeviceId {
-        self.0
-    }
+// #[derive(Clone)]
+// pub struct Device(DeviceId, TransmutableBox);
 
-    pub fn borrow_mut(&self) -> RefMut<'_, Box<dyn Transmutable>> {
-        self.1.borrow_mut()
-    }
+// impl Device {
+//     pub fn new<T>(value: T) -> Self
+//     where
+//         T: Transmutable + 'static,
+//     {
+//         Self(DeviceId::new(), wrap_transmutable(value))
+//     }
 
-    pub fn try_borrow_mut(&self) -> Result<RefMut<'_, Box<dyn Transmutable>>, BorrowMutError> {
-        self.1.try_borrow_mut()
-    }
-}
+//     pub fn id(&self) -> DeviceId {
+//         self.0
+//     }
+
+//     pub fn borrow_mut(&self) -> RefMut<'_, Box<dyn Transmutable>> {
+//         self.1.borrow_mut()
+//     }
+
+//     pub fn try_borrow_mut(&self) -> Result<RefMut<'_, Box<dyn Transmutable>>, BorrowMutError> {
+//         self.1.try_borrow_mut()
+//     }
+// }
 
 
 /*

--- a/emulator/core/src/devices.rs
+++ b/emulator/core/src/devices.rs
@@ -1,4 +1,4 @@
-use std::any::{type_name, type_name_of_val, Any, TypeId};
+use std::any::{type_name, Any, TypeId};
 use std::ops::Deref;
 use std::rc::Rc;
 use std::cell::RefCell;
@@ -232,12 +232,6 @@ pub fn downcast_rc_refc<'a, T: DynDevice>(field: &'a Device) -> Result<&'a Rc<Re
     } else {
         Err(Error::Other(format!("Type {} is not {}", field.borrow().deref().type_name(), type_name::<T>())))
     }
-}
-
-pub type TransmutableBox = Rc<RefCell<Box<dyn Transmutable>>>;
-
-pub fn wrap_transmutable<T: Transmutable + 'static>(value: T) -> TransmutableBox {
-    Rc::new(RefCell::new(Box::new(value)))
 }
 
 static NEXT_ID: AtomicU32 = AtomicU32::new(1);

--- a/emulator/core/src/lib.rs
+++ b/emulator/core/src/lib.rs
@@ -7,7 +7,7 @@ mod memory;
 mod system;
 
 pub use crate::devices::{
-    Address, Addressable, Steppable, Interruptable, Debuggable, Inspectable, Transmutable, TransmutableBox, Resource
+    Address, Addressable, Steppable, Interruptable, Debuggable, Inspectable, Transmutable, TransmutableBox, DynDevice
 };
 pub use crate::devices::{
     read_beu16, read_beu32, read_leu16, read_leu32, write_beu16, write_beu32, write_leu16, write_leu32, wrap_transmutable,

--- a/emulator/core/src/lib.rs
+++ b/emulator/core/src/lib.rs
@@ -7,10 +7,10 @@ mod memory;
 mod system;
 
 pub use crate::devices::{
-    Address, Addressable, Steppable, Interruptable, Debuggable, Inspectable, Transmutable, TransmutableBox, DynDevice
+    Address, Addressable, Steppable, Interruptable, Debuggable, Inspectable, Transmutable, TransmutableBox, DynDevice, Device,
 };
 pub use crate::devices::{
-    read_beu16, read_beu32, read_leu16, read_leu32, write_beu16, write_beu32, write_leu16, write_leu32, wrap_transmutable,
+    read_beu16, read_beu32, read_leu16, read_leu32, write_beu16, write_beu32, write_leu16, write_leu32, wrap_transmutable, wrap_device
 };
 pub use crate::error::Error;
 pub use crate::interrupts::InterruptController;

--- a/emulator/core/src/lib.rs
+++ b/emulator/core/src/lib.rs
@@ -7,7 +7,7 @@ mod memory;
 mod system;
 
 pub use crate::devices::{
-    Address, Addressable, Steppable, Interruptable, Debuggable, Inspectable, Transmutable, TransmutableBox, Device,
+    Address, Addressable, Steppable, Interruptable, Debuggable, Inspectable, Transmutable, TransmutableBox, Resource
 };
 pub use crate::devices::{
     read_beu16, read_beu32, read_leu16, read_leu32, write_beu16, write_beu32, write_leu16, write_leu32, wrap_transmutable,
@@ -15,6 +15,6 @@ pub use crate::devices::{
 pub use crate::error::Error;
 pub use crate::interrupts::InterruptController;
 pub use crate::memory::{MemoryBlock, AddressTranslator, AddressRepeater, Bus, BusPort, dump_slice, dump_memory};
-pub use crate::system::System;
+pub use crate::system::{System, DeviceSettings};
 
-pub use emulator_hal::bus::{BusAccess};
+pub use emulator_hal::bus::BusAccess;

--- a/emulator/core/src/lib.rs
+++ b/emulator/core/src/lib.rs
@@ -7,10 +7,10 @@ mod memory;
 mod system;
 
 pub use crate::devices::{
-    Address, Addressable, Steppable, Interruptable, Debuggable, Inspectable, Transmutable, TransmutableBox, DynDevice, Device,
+    Address, Addressable, Steppable, Interruptable, Debuggable, Inspectable, Transmutable, DynDevice, Device,
 };
 pub use crate::devices::{
-    read_beu16, read_beu32, read_leu16, read_leu32, write_beu16, write_beu32, write_leu16, write_leu32, wrap_transmutable, wrap_device
+    read_beu16, read_beu32, read_leu16, read_leu32, write_beu16, write_beu32, write_leu16, write_leu32, wrap_device
 };
 pub use crate::error::Error;
 pub use crate::interrupts::InterruptController;

--- a/emulator/core/src/system.rs
+++ b/emulator/core/src/system.rs
@@ -98,7 +98,7 @@ impl System {
     pub fn get_device<T: DynDevice>(&self, device: DeviceId) -> Result<Rc<RefCell<T>>, Error> {
         self.devices
             .get(&device)
-            .and_then(|rc| downcast_rc_refc::<T>(rc))
+            .and_then(|rc| downcast_rc_refc::<T>(rc).inspect_err(|e| panic!("{:?}", e)).ok())
             .cloned()
             .ok_or_else(|| Error::new(format!("system: bad device id {}", device)))
     }

--- a/emulator/frontends/minifb/src/lib.rs
+++ b/emulator/frontends/minifb/src/lib.rs
@@ -7,7 +7,7 @@ use minifb::{self, Key, MouseMode, MouseButton};
 use clap::{Command, Arg, ArgAction, ArgMatches};
 use femtos::{Duration as FemtosDuration};
 
-use moa_core::{System, Error, Device};
+use moa_core::{System, Error};
 use moa_debugger::{Debugger, DebugControl};
 use moa_host::{
     Host, HostError, Audio, KeyEvent, MouseEvent, MouseState, ControllerDevice, ControllerEvent, EventSender, PixelEncoding, Frame,
@@ -244,7 +244,7 @@ impl MiniFrontend {
 
         if self.mixer.borrow_mut().num_sources() != 0 && !matches.get_flag("disable-audio") {
             if let Some(system) = system.as_mut() {
-                system.add_device("mixer", Device::new(self.mixer.clone())).unwrap();
+                system.add_named_device("mixer", self.mixer.clone()).unwrap();
             }
             self.audio = Some(CpalAudioOutput::create_audio_output(self.mixer.borrow_mut().get_sink()));
         }

--- a/emulator/libraries/debugger/src/lib.rs
+++ b/emulator/libraries/debugger/src/lib.rs
@@ -132,13 +132,13 @@ impl Debugger {
                 if args.len() < 2 {
                     println!("Usage: inspect <device_name> [<device specific arguments>]");
                 } else {
-                    // let device = system.get_dyn_device(args[1])?;
-                    // let subargs = if args.len() > 2 { &args[2..] } else { &[""] };
-                    // device
-                    //     .borrow_mut()
-                    //     .as_inspectable()
-                    //     .ok_or_else(|| Error::new("That device is not inspectable"))?
-                    //     .inspect(system, subargs)?;
+                    let device = system.get_dyn_device_by_name(args[1])?;
+                    let subargs = if args.len() > 2 { &args[2..] } else { &[""] };
+                    device
+                        .borrow_mut()
+                        .as_inspectable()
+                        .ok_or_else(|| Error::new("That device is not inspectable"))?
+                        .inspect(system, subargs)?;
                 }
             },
             "dis" | "disassemble" => {

--- a/emulator/systems/computie/src/system.rs
+++ b/emulator/systems/computie/src/system.rs
@@ -1,6 +1,6 @@
 use femtos::Frequency;
 
-use moa_core::{System, Error, Debuggable, MemoryBlock, Device};
+use moa_core::{System, Error, Debuggable, MemoryBlock};
 use moa_host::Host;
 
 use moa_m68k::{M68k, M68kType};
@@ -28,27 +28,27 @@ pub fn build_computie<H: Host>(host: &H, options: ComputieOptions) -> Result<Sys
 
     let mut rom = MemoryBlock::new(vec![0; 0x10000]);
     rom.load_at(0x0000, &options.rom)?;
-    system.add_addressable_device(0x00000000, Device::new(rom))?;
+    system.add_addressable_device(0x00000000, rom)?;
 
     let mut ram = MemoryBlock::new(vec![0; options.ram]);
     ram.load_at(0, "binaries/computie/kernel.bin")?;
-    system.add_addressable_device(0x00100000, Device::new(ram))?;
+    system.add_addressable_device(0x00100000, ram)?;
 
     let mut ata = AtaDevice::default();
     ata.load("binaries/computie/disk-with-partition-table.img")?;
-    system.add_addressable_device(0x00600000, Device::new(ata))?;
+    system.add_addressable_device(0x00600000, ata)?;
 
     let mut serial = MC68681::default();
     launch_terminal_emulator(serial.port_a.connect(host.add_pty()?)?);
     launch_slip_connection(serial.port_b.connect(host.add_pty()?)?);
-    system.add_addressable_device(0x00700000, Device::new(serial))?;
+    system.add_addressable_device(0x00700000, serial)?;
 
 
     let mut cpu = M68k::from_type(M68kType::MC68010, options.frequency);
 
     cpu.add_breakpoint(0);
 
-    system.add_interruptable_device("cpu", Device::new(cpu))?;
+    system.add_interruptable_device("cpu", cpu)?;
 
     Ok(system)
 }
@@ -57,25 +57,25 @@ pub fn build_computie_k30<H: Host>(host: &H) -> Result<System, Error> {
     let mut system = System::default();
 
     let monitor = MemoryBlock::load("binaries/computie/monitor-68030.bin")?;
-    system.add_addressable_device(0x00000000, Device::new(monitor))?;
+    system.add_addressable_device(0x00000000, monitor)?;
 
     let mut ram = MemoryBlock::new(vec![0; 0x00100000]);
     ram.load_at(0, "binaries/computie/kernel-68030.bin")?;
-    system.add_addressable_device(0x00100000, Device::new(ram))?;
+    system.add_addressable_device(0x00100000, ram)?;
 
     let mut ata = AtaDevice::default();
     ata.load("binaries/computie/disk-with-partition-table.img")?;
-    system.add_addressable_device(0x00600000, Device::new(ata))?;
+    system.add_addressable_device(0x00600000, ata)?;
 
     let mut serial = MC68681::default();
     launch_terminal_emulator(serial.port_a.connect(host.add_pty()?)?);
     //launch_slip_connection(serial.port_b.connect(host.add_pty()?)?);
-    system.add_addressable_device(0x00700000, Device::new(serial))?;
+    system.add_addressable_device(0x00700000, serial)?;
 
 
     let cpu = M68k::from_type(M68kType::MC68030, Frequency::from_hz(10_000_000));
 
-    system.add_interruptable_device("cpu", Device::new(cpu))?;
+    system.add_interruptable_device("cpu", cpu)?;
 
     Ok(system)
 }

--- a/emulator/systems/macintosh/src/peripherals/mainboard.rs
+++ b/emulator/systems/macintosh/src/peripherals/mainboard.rs
@@ -2,7 +2,7 @@ use std::rc::Rc;
 use std::cell::RefCell;
 use femtos::{Instant, Duration};
 
-use moa_core::{System, Bus, Error, Address, Addressable, AddressRepeater, Steppable, Transmutable, Device};
+use moa_core::{wrap_device, Address, AddressRepeater, Addressable, Bus, Device, Error, Steppable, System, Transmutable};
 use moa_signals::Observable;
 
 use moa_peripherals_mos::Mos6522;
@@ -48,28 +48,28 @@ impl Mainboard {
                 lower_bus.borrow_mut().clear_all_bus_devices();
                 lower_bus
                     .borrow_mut()
-                    .insert(0x000000, Device::new(AddressRepeater::new(ram.clone(), 0x400000)));
+                    .insert(0x000000, wrap_device(AddressRepeater::new(ram.clone(), 0x400000)));
                 lower_bus
                     .borrow_mut()
-                    .insert(0x400000, Device::new(AddressRepeater::new(rom.clone(), 0x100000)));
+                    .insert(0x400000, wrap_device(AddressRepeater::new(rom.clone(), 0x100000)));
                 lower_bus
                     .borrow_mut()
-                    .insert(0x600000, Device::new(AddressRepeater::new(rom.clone(), 0x100000)));
+                    .insert(0x600000, wrap_device(AddressRepeater::new(rom.clone(), 0x100000)));
             } else {
                 println!("{}: overlay is 1 (startup)", DEV_NAME);
                 lower_bus.borrow_mut().clear_all_bus_devices();
                 lower_bus
                     .borrow_mut()
-                    .insert(0x000000, Device::new(AddressRepeater::new(rom.clone(), 0x100000)));
+                    .insert(0x000000, wrap_device(AddressRepeater::new(rom.clone(), 0x100000)));
                 lower_bus
                     .borrow_mut()
-                    .insert(0x200000, Device::new(AddressRepeater::new(rom.clone(), 0x100000)));
+                    .insert(0x200000, wrap_device(AddressRepeater::new(rom.clone(), 0x100000)));
                 lower_bus
                     .borrow_mut()
-                    .insert(0x400000, Device::new(AddressRepeater::new(rom.clone(), 0x100000)));
+                    .insert(0x400000, wrap_device(AddressRepeater::new(rom.clone(), 0x100000)));
                 lower_bus
                     .borrow_mut()
-                    .insert(0x600000, Device::new(AddressRepeater::new(ram.clone(), 0x200000)));
+                    .insert(0x600000, wrap_device(AddressRepeater::new(ram.clone(), 0x200000)));
             }
         });
 

--- a/emulator/systems/macintosh/src/system.rs
+++ b/emulator/systems/macintosh/src/system.rs
@@ -1,6 +1,6 @@
 use femtos::Frequency;
 
-use moa_core::{System, Error, MemoryBlock, Debuggable, Device};
+use moa_core::{wrap_device, Debuggable, Error, MemoryBlock, System};
 use moa_host::Host;
 
 use moa_m68k::{M68k, M68kType};
@@ -64,10 +64,10 @@ pub fn build_macintosh_512k<H: Host>(host: &mut H) -> Result<System, Error> {
     rom.read_only();
 
     let video = MacVideo::new(host)?;
-    system.add_device("video", Device::new(video)).unwrap();
+    system.add_named_device("video", video).unwrap();
 
-    let mainboard = Mainboard::new(Device::new(ram), Device::new(rom))?;
-    system.add_addressable_device(0x00000000, Device::new(mainboard))?;
+    let mainboard = Mainboard::new(wrap_device(ram), wrap_device(rom))?;
+    system.add_addressable_device(0x00000000, mainboard)?;
 
 
     let mut cpu = M68k::from_type(M68kType::MC68000, Frequency::from_hz(7_833_600));
@@ -122,7 +122,7 @@ pub fn build_macintosh_512k<H: Host>(host: &mut H) -> Result<System, Error> {
     panic!("");
     */
 
-    system.add_interruptable_device("cpu", Device::new(cpu))?;
+    system.add_interruptable_device("cpu", cpu)?;
 
     Ok(system)
 }

--- a/emulator/systems/trs80/src/system.rs
+++ b/emulator/systems/trs80/src/system.rs
@@ -1,6 +1,6 @@
 use femtos::Frequency;
 
-use moa_core::{System, Error, MemoryBlock, Device};
+use moa_core::{System, Error, MemoryBlock};
 use moa_host::Host;
 
 use moa_z80::{Z80, Z80Type};
@@ -33,20 +33,20 @@ pub fn build_trs80<H: Host>(host: &mut H, options: Trs80Options) -> Result<Syste
     //rom.load_at(0x0000, "binaries/trs80/level2.rom")?;
     rom.load_at(0x0000, &options.rom)?;
     rom.read_only();
-    system.add_addressable_device(0x0000, Device::new(rom))?;
+    system.add_addressable_device(0x0000, rom)?;
 
     let ram = MemoryBlock::new(vec![0; options.memory as usize]);
-    system.add_addressable_device(0x4000, Device::new(ram))?;
+    system.add_addressable_device(0x4000, ram)?;
 
     let keyboard = Model1Keyboard::new(host)?;
-    system.add_addressable_device(0x37E0, Device::new(keyboard)).unwrap();
+    system.add_addressable_device(0x37E0, keyboard).unwrap();
     let video = Model1Video::new(host)?;
-    system.add_addressable_device(0x37E0 + 0x420, Device::new(video)).unwrap();
+    system.add_addressable_device(0x37E0 + 0x420, video).unwrap();
 
     // TODO the ioport needs to be hooked up
     let cpu = Z80::from_type(Z80Type::Z80, options.frequency, system.bus.clone(), 0, None);
 
-    system.add_interruptable_device("cpu", Device::new(cpu))?;
+    system.add_interruptable_device("cpu", cpu)?;
 
     Ok(system)
 }

--- a/tests/rad_tests/src/main.rs
+++ b/tests/rad_tests/src/main.rs
@@ -13,7 +13,7 @@ use flate2::read::GzDecoder;
 use serde_derive::Deserialize;
 use femtos::Frequency;
 
-use moa_core::{System, Error, MemoryBlock, Bus, BusPort, Address, Addressable, Steppable, Device};
+use moa_core::{System, Error, MemoryBlock, Bus, BusPort, Address, Addressable, Steppable};
 
 use moa_z80::{Z80, Z80Type};
 use moa_z80::instructions::InterruptMode;
@@ -150,10 +150,10 @@ fn init_execute_test(cputype: Z80Type, state: &TestState, ports: &[TestPort]) ->
 
     // Insert basic initialization
     let mem = MemoryBlock::new(vec![0; 0x1_0000]);
-    system.add_addressable_device(0x00000000, Device::new(mem)).unwrap();
+    system.add_addressable_device(0x00000000, mem).unwrap();
 
     // Set up IOREQ as memory space
-    let io_ram = Device::new(MemoryBlock::new(vec![0; 0x10000]));
+    let io_ram = Rc::new(RefCell::new(MemoryBlock::new(vec![0; 0x10000])));
     let io_bus = Rc::new(RefCell::new(Bus::default()));
     io_bus.borrow_mut().set_ignore_unmapped(true);
     io_bus.borrow_mut().insert(0x0000, io_ram);


### PR DESCRIPTION
This PR reworks system so wrapping every device in `Device` is no longer needed.
`Device` is now a type of `Rc<RefCell<dyn DynDevice>>` where `DynDevice` is `trait DynDevice: Any + 'static + Transmutable`.
That way the Transmutable methods can be called on the new Device type, making it work very similarly to the old one.
It also allows access to any device added to a system by calling `get_device` or `get_device_by_name` on the system, with the type of the device as a generic. The generic is checked against the type id of the `dyn DynDevice` and will error out if they don't match, a cast to a different device by accident is not possible. This system is used in the deno projects core for a resource table whic is used extensively.
`DynDevice` is implemented for every type that implements `Transmutable + 'static`, so devices do not have to implement it manually.
Adding a new device to the system now returns a `DeviceId` which can be used to get access to the device again. If the id is unknown, devices can also be found through their set name (if they have one).

The event queue and debuggables list now both hold device ids instead of the device directly.
There is now a `DeviceSettings` struct which can be used when adding a device to a system. Methods like `add_addressable_device, add_interruptable_device, add_peripheral` still exists but use `DeviceSettings` internaly 